### PR TITLE
Allow squash merge commits to be seen in go-lives

### DIFF
--- a/lib/lita/handlers/github_prs/git_diff.rb
+++ b/lib/lita/handlers/github_prs/git_diff.rb
@@ -32,7 +32,15 @@ module Lita
         private
 
         def pull_request_commit?(commit)
+          merge_commit?(commit) || squash_merge_commit?(commit)
+        end
+
+        def merge_commit?(commit)
           commit.message.start_with?('Merge pull request')
+        end
+
+        def squash_merge_commit?(commit)
+          commit.message.match(%r{\(#\d+\)$})
         end
       end
     end

--- a/spec/lita/handlers/github_prs/git_diff_spec.rb
+++ b/spec/lita/handlers/github_prs/git_diff_spec.rb
@@ -65,6 +65,19 @@ RSpec.describe Lita::Handlers::GithubPrs::GitDiff do
       expect(git_diff.pull_requests).to eq([merge_commit.commit])
     end
 
+    it 'returns all squash merge commits from pull requests' do
+      squash_merge_commit = build_commit('Sqush merge from pr (#192)')
+      commits = [
+        build_commit('Fiddle with fiddlesticks'),
+        squash_merge_commit,
+        build_commit('Fix world hunger')
+      ]
+      diff = build_diff(commits: commits)
+      git_diff = Lita::Handlers::GithubPrs::GitDiff.new(diff)
+
+      expect(git_diff.pull_requests).to eq([squash_merge_commit.commit])
+    end
+
     it 'returns an empty list when there are no merge commits' do
       files = [
         build_commit('Fiddle with fiddlesticks'),


### PR DESCRIPTION
## Background
While aiming for more isolated commits that reflects a full pull request,
squash merging is a great tool. These changes will allow them to be
visible within the go live pr

## Changes
- Allow squash merge commits to be listed among the listed PRs